### PR TITLE
OEL-288: Fix composer.json and phpunit.xml.dist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,11 @@
         "http-interop/http-factory-guzzle": "^1.0",
         "openeuropa/code-review": "2.x-dev",
         "php-http/guzzle7-adapter": "^1.0",
-        "phpunit/phpunit": "^7.5 || ^8 || ^9"
+        "phpunit/phpunit": "^9"
+    },
+    "suggest": {
+        "http-interop/http-factory-guzzle": "PSR-17 HTTP Factories implementation for Guzzle",
+        "php-http/guzzle7-adapter": "PSR-18 HTTP Client implementation for Guzzle"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true">
-    <testsuites>
-        <testsuite name="Europa Search client Test suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory>./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Europa Search client Test suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true">
+<phpunit bootstrap="vendor/autoload.php" colors="true">
   <coverage>
     <include>
       <directory>./src</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage includeUncoveredFiles="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true">
+  <coverage>
     <include>
       <directory>./src</directory>
     </include>


### PR DESCRIPTION
Changes added to this version are:
- composer.json: Restore suggestions. Set the phpunit version to ^9.
- phpunit.xml.dist: After passing phpunit tests locally, a warning appeared suggesting that xml schema needed an adaptation. So we ran with --migrate-configuration and the resulting xml has been updated inside phpunit.xml.dist.

Tests php unit passed. Installed with composer install and composer install --no-dev.
