### PR TITLE
OEL-297: ESC use Middleware:history

### DIFF
--- a/tests/src/Api/DeleteApiTest.php
+++ b/tests/src/Api/DeleteApiTest.php
@@ -27,22 +27,15 @@ class DeleteApiTest extends TestCase
      */
     public function testDeleteDocument(array $clientConfig, array $responses, $expectedResult): void
     {
-        $actualResult = $this->getTestingClient($clientConfig, $responses, [$this, 'inspectRequest'])
+        $actualResult = $this->getTestingClient($clientConfig, $responses)
             ->deleteDocument('foo');
         $this->assertSame($expectedResult, $actualResult);
-    }
-
-    /**
-     * @param RequestInterface $request
-     */
-    public function inspectRequest(RequestInterface $request): void
-    {
-        if ($request->getUri() == 'http://example.com/token') {
-            $this->inspectTokenRequest($request);
-        } else {
-            $this->assertEquals('http://example.com/ingest/delete?apiKey=bananas&database=cucumbers&reference=foo', $request->getUri());
-            $this->inspectAuthorizationHeaders($request);
-        }
+        $this->assertCount(2, $this->clientHistory);
+        $request = $this->clientHistory[0]['request'];
+        $this->inspectTokenRequest($request);
+        $request = $this->clientHistory[1]['request'];
+        $this->assertEquals('http://example.com/ingest/delete?apiKey=bananas&database=cucumbers&reference=foo', $request->getUri());
+        $this->inspectAuthorizationHeaders($request);
     }
 
     /**

--- a/tests/src/Api/FacetApiTest.php
+++ b/tests/src/Api/FacetApiTest.php
@@ -42,7 +42,7 @@ class FacetApiTest extends TestCase
      */
     public function testGetFacets(array $clientConfig, array $responses, $expectedResult): void
     {
-        $actualResult = $this->getTestingClient($clientConfig, $responses, [$this, 'inspectRequest'])
+        $actualResult = $this->getTestingClient($clientConfig, $responses)
             ->getFacets(
                 'whatever',
                 ['en', 'de'],
@@ -52,13 +52,8 @@ class FacetApiTest extends TestCase
                 '21edswq223rews'
             );
         $this->assertEquals($expectedResult, $actualResult);
-    }
-
-    /**
-     * @param RequestInterface $request
-     */
-    public function inspectRequest(RequestInterface $request): void
-    {
+        $this->assertCount(1, $this->clientHistory);
+        $request = $this->clientHistory[0]['request'];
         $this->assertEquals('http://example.com/facet?apiKey=foo&database=qux&text=whatever&sessionToken=21edswq223rews&sort=ALPHABETICAL', $request->getUri());
         $boundary = $this->getBoundary($request);
         $this->assertBoundary($request, $boundary);

--- a/tests/src/Api/FileIngestionApiTest.php
+++ b/tests/src/Api/FileIngestionApiTest.php
@@ -28,7 +28,7 @@ class FileIngestionApiTest extends TestCase
      */
     public function testFileIngestion(array $clientConfig, array $responses, $expectedResult): void
     {
-        $actualResult = $this->getTestingClient($clientConfig, $responses, [$this, 'inspectRequest'])
+        $actualResult = $this->getTestingClient($clientConfig, $responses)
             ->ingestFile(
                 'http://example.com',
                 file_get_contents(__DIR__ . '/../../fixtures/files/image.png'),
@@ -44,30 +44,23 @@ class FileIngestionApiTest extends TestCase
                 ['group003', 'group004']
             );
         $this->assertEquals($expectedResult, $actualResult);
-    }
-
-    /**
-     * @param RequestInterface $request
-     */
-    public function inspectRequest(RequestInterface $request): void
-    {
-        if ($request->getUri() == 'http://example.com/token') {
-            $this->inspectTokenRequest($request);
-        } else {
-            $this->assertEquals('http://example.com/ingest?apiKey=bananas&database=cucumbers&uri=http%3A%2F%2Fexample.com&language=%5B%22en%22%2C%22ro%22%5D&reference=unique-my-ID', $request->getUri());
-            $this->inspectAuthorizationHeaders($request);
-            $boundary = $this->getBoundary($request);
-            $this->assertBoundary($request, $boundary);
-            $parts = $this->getMultiParts($request, $boundary);
-            $this->assertCount(6, $parts);
-            $fileData = file_get_contents(__DIR__ . '/../../fixtures/files/image.png');
-            $this->inspectPart($parts[0], 'application/json', 'metadata', 55, '{"field1":["value1","value2"],"field2":["value3",2345]}');
-            $this->inspectPart($parts[1], 'application/json', 'aclUsers', 20, '["user001","user02"]');
-            $this->inspectPart($parts[2], 'application/json', 'aclNolUsers', 20, '["user003","user04"]');
-            $this->inspectPart($parts[3], 'application/json', 'aclGroups', 23, '["group001","group002"]');
-            $this->inspectPart($parts[4], 'application/json', 'aclNoGroups', 23, '["group003","group004"]');
-            $this->inspectPart($parts[5], 'image/png', 'file', 67, $fileData);
-        }
+        $this->assertCount(2, $this->clientHistory);
+        $request = $this->clientHistory[0]['request'];
+        $this->inspectTokenRequest($request);
+        $request = $this->clientHistory[1]['request'];
+        $this->assertEquals('http://example.com/ingest?apiKey=bananas&database=cucumbers&uri=http%3A%2F%2Fexample.com&language=%5B%22en%22%2C%22ro%22%5D&reference=unique-my-ID', $request->getUri());
+        $this->inspectAuthorizationHeaders($request);
+        $boundary = $this->getBoundary($request);
+        $this->assertBoundary($request, $boundary);
+        $parts = $this->getMultiParts($request, $boundary);
+        $this->assertCount(6, $parts);
+        $fileData = file_get_contents(__DIR__ . '/../../fixtures/files/image.png');
+        $this->inspectPart($parts[0], 'application/json', 'metadata', 55, '{"field1":["value1","value2"],"field2":["value3",2345]}');
+        $this->inspectPart($parts[1], 'application/json', 'aclUsers', 20, '["user001","user02"]');
+        $this->inspectPart($parts[2], 'application/json', 'aclNolUsers', 20, '["user003","user04"]');
+        $this->inspectPart($parts[3], 'application/json', 'aclGroups', 23, '["group001","group002"]');
+        $this->inspectPart($parts[4], 'application/json', 'aclNoGroups', 23, '["group003","group004"]');
+        $this->inspectPart($parts[5], 'image/png', 'file', 67, $fileData);
     }
 
     /**

--- a/tests/src/Api/InfoApiTest.php
+++ b/tests/src/Api/InfoApiTest.php
@@ -28,18 +28,10 @@ class InfoApiTest extends TestCase
      */
     public function testGetInfo(array $clientConfig, array $responses, $expectedResult): void
     {
-        $actualResult = $this->getTestingClient($clientConfig, $responses, [
-            $this,
-            'inspectRequest',
-        ])->getInfo();
+        $actualResult = $this->getTestingClient($clientConfig, $responses)->getInfo();
         $this->assertEquals($expectedResult, $actualResult);
-    }
-
-    /**
-     * @param RequestInterface $request
-     */
-    public function inspectRequest(RequestInterface $request): void
-    {
+        $this->assertCount(1, $this->clientHistory);
+        $request = $this->clientHistory[0]['request'];
         $this->assertEquals('http://example.com/search/info', $request->getUri());
     }
 

--- a/tests/src/Api/SearchApiTest.php
+++ b/tests/src/Api/SearchApiTest.php
@@ -30,7 +30,7 @@ class SearchApiTest extends TestCase
      */
     public function testSearch(array $clientConfig, array $responses, $expectedResult): void
     {
-        $actualResult = $this->getTestingClient($clientConfig, $responses, [$this, 'inspectRequest'])
+        $actualResult = $this->getTestingClient($clientConfig, $responses)
             ->search(
                 'Programme managers',
                 ['en', 'de'],
@@ -44,13 +44,8 @@ class SearchApiTest extends TestCase
                 '21edswq223rews'
             );
         $this->assertEquals($expectedResult, $actualResult);
-    }
-
-    /**
-     * @param RequestInterface $request
-     */
-    public function inspectRequest(RequestInterface $request): void
-    {
+        $this->assertCount(1, $this->clientHistory);
+        $request = $this->clientHistory[0]['request'];
         $this->assertEquals('http://example.com/search?apiKey=foo&database=bar&text=Programme+managers&sessionToken=21edswq223rews&pageNumber=2&pageSize=5&highlightRegex=%7Bw%2B%7D&highlightLimit=150', $request->getUri());
         $boundary = $this->getBoundary($request);
         $this->assertBoundary($request, $boundary);


### PR DESCRIPTION
Add use of Middleware::history into API test classes:
- ApiBaseTest.php
- DeleteApiTest.php → Contains assertRequest instead of inspectRequest
- FacetApiTest.php
- FileIngestionApiTest.php
- InfoApiTest.php
- SearchApiTest.php
- TokenApiTest.php

Work done:
- Move inspectRequest into main paragraph
- Boundary changes
- Proper call to getTestingClient
- Assert history count
